### PR TITLE
Removed extra vertical space in ctf.component.tsx.

### DIFF
--- a/src/components/ctf/ctf.component.tsx
+++ b/src/components/ctf/ctf.component.tsx
@@ -46,9 +46,7 @@ const CTFComponent = () => {
 
                 <div className="section-title">
                     <h2>What kind of challenges will there be?</h2>
-                </div>
-
-                <div className="content">
+                
                     <p>
                         We plan to have a diverse range of challenges so that no matter what your skill set is, there will be something for you to tackle and keep you entertained. Challenges will cover:
                     </p>


### PR DESCRIPTION
Removed extra space, unlike the rest of the page, this was using a seperate div for the content which created an extra spacing.

Before fix
<img width="907" alt="Screenshot 2024-11-13 at 00 49 03" src="https://github.com/user-attachments/assets/abb21073-d8ef-47df-a8b4-28ca056a0b12">

After fix
<img width="877" alt="Screenshot 2024-11-13 at 00 50 26" src="https://github.com/user-attachments/assets/3086b33f-17eb-486a-a317-bb1b09f8f04a">
