### PR TITLE
Replace 'NUI' with 'University of'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,25 +7,25 @@
             <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
             <!-- Primary Meta Tags -->
-            <meta name="title" content="CompSoc - NUI Galway's Computer Society">
+            <meta name="title" content="CompSoc - University of Galway's Computer Society">
             <meta name="description"
-                  content="CompSoc is the longest running Computer Society in Ireland, and a social outlet for NUI Galway students interested in technology.">
+                  content="CompSoc is the longest running Computer Society in Ireland, and a social outlet for University of Galway students interested in technology.">
 
             <!-- Open Graph / Facebook -->
             <meta property="og:type" content="website">
             <meta property="og:url" content="https:/compsoc.ie">
-            <meta property="og:title" content="CompSoc - NUI Galway's Computer Society">
+            <meta property="og:title" content="CompSoc - University of Galway's Computer Society">
             <meta property="og:description"
-                  content="CompSoc is the longest running Computer Society in Ireland, and a social outlet for NUI Galway students interested in technology.">
+                  content="CompSoc is the longest running Computer Society in Ireland, and a social outlet for University of Galway students interested in technology.">
             <meta property="og:image"
                   content="/assets/img/compsoc-meta-social-banner.png">
 
             <!-- Twitter -->
             <meta property="twitter:card" content="summary_large_image">
             <meta property="twitter:url" content="https:/compsoc.ie">
-            <meta property="twitter:title" content="CompSoc - NUI Galway's Computer Society">
+            <meta property="twitter:title" content="CompSoc - University of Galway's Computer Society">
             <meta property="twitter:description"
-                  content="CompSoc is the longest running Computer Society in Ireland, and a social outlet for NUI Galway students interested in technology.">
+                  content="CompSoc is the longest running Computer Society in Ireland, and a social outlet for University of Galway students interested in technology.">
             <meta property="twitter:image"
                   content="/assets/img/compsoc-meta-social-banner.png">
 


### PR DESCRIPTION
Replace 'NUI' with 'University of' in <meta> tags.

Essentially just changes preview thumbnails to use the updated name of the university, as before this change, this is what a preview thumbnail looked like:
![image](https://github.com/user-attachments/assets/8bcde221-9bd9-4641-95d0-a32a0184023b)
