### PR TITLE
Updated ctf page to include info about catering order timeline

### DIFF
--- a/src/components/ctf/ctf.component.tsx
+++ b/src/components/ctf/ctf.component.tsx
@@ -101,8 +101,9 @@ const CTFComponent = () => {
 
                     <div className="faq-item">
                         <h4><strong>What can I do for food?</strong></h4>
-                        <p>We’ll have a hot lunch (and perhaps some other treats), with both meat and vegetarian options available.<br />
-                            There is a Tesco and a Centra open nearby, alongside lots of other food outlets if something else takes your fancy.</p>
+                        <p>We’ll have a hot lunch (and perhaps some other treats), with both meat, vegetarian and gluten free options available.<br />
+                        <strong>Note: if you purchase your ticket after midnight, Wednesday the 29th, we will not be able to include you in the catering order</strong><br />
+                        There is a Tesco and a Centra open nearby, alongside lots of other food outlets if something else takes your fancy.</p>
                     </div>
 
                     <div className="faq-item">


### PR DESCRIPTION
Updated ctf page to include info about catering order timeline
<img width="1101" alt="Screenshot 2025-01-22 at 10 07 30" src="https://github.com/user-attachments/assets/bdccaab0-a575-4edf-afb3-c1c5a50c23c5" />
